### PR TITLE
[package.json: scripts] Add build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Convert any number less than 4000 to roman numerals and back to integer",
   "main": "index.js",
   "scripts": {
+    "build": "tsc && npm run format",
     "test": "jest tests/*.test.js",
     "prepare": "husky install",
     "format": "prettier --write \"**/*.{js,jsx,json,css,md}\""
@@ -29,7 +30,8 @@
     "jest": "^29.1.2",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
-    "ts-jest": "^29.0.3"
+    "ts-jest": "^29.0.3",
+    "typescript": "^4.8.4"
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --write"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Convert any number less than 4000 to roman numerals and back to integer",
   "main": "index.js",
   "scripts": {
-    "build": "tsc && npm run format",
+    "build": "tsc",
     "test": "jest tests/*.test.js",
     "prepare": "husky install",
     "format": "prettier --write \"**/*.{js,jsx,json,css,md}\""


### PR DESCRIPTION
Hello!
When I looked at your project, I noticed that the `build` command is not present.
Since it is written in TypeScript, I thought it would be better if the `build` command was also listed in `package.json`, so I added it.

Also, the built js files seemed to be formatted, so I'm trying to run `npm run format` after the build.
(I confirmed from `.gitignore` that this project uses `npm`)

What do you think?